### PR TITLE
Change scratch register of tail to t2 when Zicfilp enabled.

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -802,7 +802,7 @@ the current position:
 
 [^3]: `ra` is implicitly used to save the return address.
 [^4]: similar to `call <symbol>`, but `<rd>` is used to save the return address instead.
-[^5]: `t1` is implicitly used as a scratch register.
+[^5]: If the `Zicfilp` extension is available, `t2` is implicitly used as a scratch register. Otherwise,`t1` is implicitly used as a scratch register.
 [^6]: similar to `tail <symbol>`, but `<rt>` is used as the scratch register instead.
 
 The following example shows how these pseudoinstructions are used:
@@ -964,7 +964,7 @@ jr rs                        | jalr x0, rs, 0                                   
 jalr rs                      | jalr x1, rs, 0                                                | Jump and link register
 ret                          | jalr x0, x1, 0                                                | Return from subroutine
 call offset                  | auipc x1, offset[31:12] <br>jalr x1, x1, offset[11:0]         | Call far-away subroutine
-tail offset                  | auipc x6, offset[31:12] <br>jalr x0, x6, offset[11:0]         | Tail call far-away subroutine
+tail offset                  | auipc x6, offset[31:12] <br>jalr x0, x6, offset[11:0]         | Tail call far-away subroutine | It will use `x7` as scratch register when `Zicfilp` extension is available.
 fence                        | fence iorw, iorw                                              | Fence on all memory and I/O
 pause                        | fence w, 0                                                    | PAUSE hint
 


### PR DESCRIPTION
This change is to make `tail` conform with software guarded jump of [Zicfilp]. The reason to not choose `t1` as the label register is that `t1` is also as `.got.plt` offset of `_dl_runtime_resolve` in [PLT].

[Zicfilp]: https://github.com/riscv/riscv-cfi/blob/main/cfi_forward.adoc
[PLT]: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#procedure-linkage-table