### PR TITLE
Add CI workflow to create PDF/HTML

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -1,0 +1,71 @@
+name: Create Document
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - created
+
+# Cancel any older workflow runs for PRs that are still in progress, so
+# pushing quickly several times does not create too much load.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.2.2
+      with:
+        submodules: recursive
+    - name: Run build
+      run: make docker-pull-latest build
+      env:
+        VERSION: v${{ github.event.inputs.version }}
+        REVMARK: ${{ github.event.inputs.revision_mark }}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4.4.3
+      with:
+        name: riscv-asm-manual.zip
+        path: |
+            build/riscv-asm.pdf
+            build/riscv-asm.html
+
+  release-draft:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+      - name: Get timestamp
+        id: date
+        run: echo "RELEASE_DATE=$(date --utc +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2.1.0
+        with:
+          draft: true
+          name: Draft release ${{ steps.date.outputs.RELEASE_DATE }}
+          body: Snapshot (${{ github.sha }})
+          files: |
+            riscv-asm-manual.zip/riscv-asm.pdf
+            riscv-asm-manual.zip/riscv-asm.html
+
+  release:
+    if: (github.event_name == 'release' && github.event.action == 'created')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+      - name: Upload assets
+        uses: softprops/action-gh-release@v2.1.0
+        with:
+          files: |
+            riscv-asm-manual.zip/riscv-asm.pdf
+            riscv-asm-manual.zip/riscv-asm.html

--- a/src/preamble.adoc
+++ b/src/preamble.adoc
@@ -1,10 +1,10 @@
 [preface]
 == Copyright and License Information
 
-The RISC-V Assembly Programmer's Manual is
-(C) 2017 Palmer Dabbelt mailto:palmer@dabbelt.com[palmer@dabbelt.com],
-(C) 2017 Michael Clark mailto:michaeljclark@mac.com[michaeljclark@mac.com] and,
-(C) 2017 Alex Bradbury mailto:asb@lowrisc.org[asb@lowrisc.org].
+The RISC-V Assembly Programmer's Manual is +
+(C) 2017 Palmer Dabbelt mailto:palmer@dabbelt.com[palmer@dabbelt.com], +
+(C) 2017 Michael Clark mailto:michaeljclark@mac.com[michaeljclark@mac.com] and, +
+(C) 2017 Alex Bradbury mailto:asb@lowrisc.org[asb@lowrisc.org]. +
 
 It is licensed under the Creative Commons Attribution 4.0 International License (CC-BY 4.0).
 


### PR DESCRIPTION
Address https://github.com/riscv-non-isa/riscv-asm-manual/issues/112

- Add CI workflow to create PDF/HTML and draft release for every push to main
- improve PDF content layout

See here how it looks like: https://github.com/axel-h/riscv-asm-manual/releases

