### PR TITLE
Add fgt.[hsd] and fge.[hsd] pseudo-instructions

### DIFF
--- a/src/asm-manual.adoc
+++ b/src/asm-manual.adoc
@@ -1058,6 +1058,9 @@ srli rd, rd, XLEN - 32
 |snez rd, rs                  | sltu rd, x0, rs                                               | Set if != zero |
 |sltz rd, rs                  | slt rd, rs, x0                                                | Set if < zero |
 |sgtz rd, rs                  | slt rd, x0, rs                                                | Set if > zero |
+|fmv.h frd, frs               | fsgnj.h frd, frs, frs                                         | Copy half-precision register |
+|fabs.h frd, frs              | fsgnjx.h frd, frs, frs                                        | Half-precision absolute value |
+|fneg.h frd, frs              | fsgnjn.h frd, frs, frs                                        | Half-precision negate |
 |fmv.s frd, frs               | fsgnj.s frd, frs, frs                                         | Copy single-precision register |
 |fabs.s frd, frs              | fsgnjx.s frd, frs, frs                                        | Single-precision absolute value |
 |fneg.s frd, frs              | fsgnjn.s frd, frs, frs                                        | Single-precision negate |

--- a/src/asm-manual.adoc
+++ b/src/asm-manual.adoc
@@ -1058,12 +1058,12 @@ srli rd, rd, XLEN - 32
 |snez rd, rs                  | sltu rd, x0, rs                                               | Set if != zero |
 |sltz rd, rs                  | slt rd, rs, x0                                                | Set if < zero |
 |sgtz rd, rs                  | slt rd, x0, rs                                                | Set if > zero |
-|fmv.s rd, rs                 | fsgnj.s rd, rs, rs                                            | Copy single-precision register |
-|fabs.s rd, rs                | fsgnjx.s rd, rs, rs                                           | Single-precision absolute value |
-|fneg.s rd, rs                | fsgnjn.s rd, rs, rs                                           | Single-precision negate |
-|fmv.d rd, rs                 | fsgnj.d rd, rs, rs                                            | Copy double-precision register |
-|fabs.d rd, rs                | fsgnjx.d rd, rs, rs                                           | Double-precision absolute value |
-|fneg.d rd, rs                | fsgnjn.d rd, rs, rs                                           | Double-precision negate |
+|fmv.s frd, frs               | fsgnj.s frd, frs, frs                                         | Copy single-precision register |
+|fabs.s frd, frs              | fsgnjx.s frd, frs, frs                                        | Single-precision absolute value |
+|fneg.s frd, frs              | fsgnjn.s frd, frs, frs                                        | Single-precision negate |
+|fmv.d frd, frs               | fsgnj.d frd, frs, frs                                         | Copy double-precision register |
+|fabs.d frd, frs              | fsgnjx.d frd, frs, frs                                        | Double-precision absolute value |
+|fneg.d frd, frs              | fsgnjn.d frd, frs, frs                                        | Double-precision negate |
 |beqz rs, offset              | beq rs, x0, offset                                            | Branch if = zero |
 |bnez rs, offset              | bne rs, x0, offset                                            | Branch if != zero |
 |blez rs, offset              | bge x0, rs, offset                                            | Branch if ≤ zero |

--- a/src/asm-manual.adoc
+++ b/src/asm-manual.adoc
@@ -1061,12 +1061,18 @@ srli rd, rd, XLEN - 32
 |fmv.h frd, frs               | fsgnj.h frd, frs, frs                                         | Copy half-precision register |
 |fabs.h frd, frs              | fsgnjx.h frd, frs, frs                                        | Half-precision absolute value |
 |fneg.h frd, frs              | fsgnjn.h frd, frs, frs                                        | Half-precision negate |
+|fgt.h rd, frs, frt           | flt.h rd, frt, frs                                            | Half-precision > |
+|fge.h rd, frs, frt           | fle.h rd, frt, frs                                            | Half-precision >= |
 |fmv.s frd, frs               | fsgnj.s frd, frs, frs                                         | Copy single-precision register |
 |fabs.s frd, frs              | fsgnjx.s frd, frs, frs                                        | Single-precision absolute value |
 |fneg.s frd, frs              | fsgnjn.s frd, frs, frs                                        | Single-precision negate |
+|fgt.s rd, frs, frt           | flt.s rd, frt, frs                                            | Single-precision > |
+|fge.s rd, frs, frt           | fle.s rd, frt, frs                                            | Single-precision >= |
 |fmv.d frd, frs               | fsgnj.d frd, frs, frs                                         | Copy double-precision register |
 |fabs.d frd, frs              | fsgnjx.d frd, frs, frs                                        | Double-precision absolute value |
 |fneg.d frd, frs              | fsgnjn.d frd, frs, frs                                        | Double-precision negate |
+|fgt.d rd, frs, frt           | flt.d rd, frt, frs                                            | Double-precision > |
+|fge.d rd, frs, frt           | fle.d rd, frt, frs                                            | Double-precision >= |
 |beqz rs, offset              | beq rs, x0, offset                                            | Branch if = zero |
 |bnez rs, offset              | bne rs, x0, offset                                            | Branch if != zero |
 |blez rs, offset              | bge x0, rs, offset                                            | Branch if ≤ zero |


### PR DESCRIPTION
Those two pseudo-instructions are trivial and also already implemented in the
binutils[1] and LLVM[2].

[1] https://github.com/bminor/binutils-gdb/commit/e23eba971dd409b999dd83d8df0f842680c1c642
[2] https://github.com/llvm/llvm-project/commit/84080793c56558b6e677fa70577e87e2e8404816

NOTE: bintuils supports those 2 kind of pseudo-instructions since RISC-V support began.

---

Also come with 2 small patch for tweak the document:
- `Add .h variant of floating point pesudo instructions`
- `Use fr[ds] for FPR to prevent confuse with GPR for floating point pesudo instructions`
