### PR TITLE
Fix GOT-indirect addressing example output

### DIFF
--- a/src/asm-manual.adoc
+++ b/src/asm-manual.adoc
@@ -582,15 +582,15 @@ The following example shows how to load an address from the GOT:
   ld  a0, %pcrel_lo(1b)(a0)
 ----
 
-Which generates the following assembler output and relocations
-as seen by `objdump`:
+This generates the following instructions and relocations as seen by `objdump`
+(for RV64; RV32 will use `lw` instead of `ld`):
 
 [source, asm]
 ----
 0000000000000000 <.text>:
    0: 00000517            auipc a0,0x0
       0: R_RISCV_GOT_HI20 msg+0x1
-   4: 00050513            mv  a0,a0
+   4: 00053503            ld  a0,0(a0) # 0 <.text>
       4: R_RISCV_PCREL_LO12_I .L1
 ----
 


### PR DESCRIPTION
The GOT-indirect addressing example uses:

    ld a0, %pcrel_lo(1b)(a0)

so the objdump output should show an RV64 load from the GOT entry rather than
`mv a0,a0`, which appears to have been copied from the previous PC-relative
addressing example.

Also clarify that the shown output is for RV64; RV32 uses `lw` instead.

Verified with riscv64-unknown-elf-as and riscv64-unknown-elf-objdump.

A Compiler Explorer reproduction is also available:
https://godbolt.org/z/Tsse84qae

Ref #78.